### PR TITLE
The toolbar can now span on multiple rows using the '/' separator

### DIFF
--- a/Source/MooEditable/MooEditable.js
+++ b/Source/MooEditable/MooEditable.js
@@ -1067,7 +1067,13 @@ MooEditable.UI.Toolbar= new Class({
 			this.el.adopt(this.content);
 		} else {
 			this.content = actions.map(function(action){
-				return (action == '|') ? this.addSeparator() : this.addItem(action);
+				if (action == '|') {
+					return this.addSeparator();
+				}
+				else if (action == '/') {
+					return this.addLineSeparator();
+				}
+				return this.addItem(action);
 			}.bind(this));
 		}
 		return this;
@@ -1095,9 +1101,13 @@ MooEditable.UI.Toolbar= new Class({
 	},
 	
 	addSeparator: function(){
-		return new Element('span', {'class': 'toolbar-separator'}).inject(this.el);
+		return new Element('span.toolbar-separator').inject(this.el);
 	},
-	
+
+	addLineSeparator: function(){
+		return new Element('div.toolbar-line-separator').inject(this.el);
+	},
+
 	itemAction: function(){
 		this.fireEvent('itemAction', arguments);
 	},


### PR DESCRIPTION
Hello,

Using the "/" separator the toolbar can now span on multiple rows:

"bold italic underline strikethrough | formatBlock justifyleft justifyright justifycenter justifyfull / tableadd | tableedit | tablerowspan tablerowsplit tablerowdelete | tablecolspan tablecolsplit tablecoldelete"

Best Regards,

Olivier Laviale
