### PR TITLE
IE and firefox issue with underline back fixed.

### DIFF
--- a/Source/MooEditable/MooEditable.js
+++ b/Source/MooEditable/MooEditable.js
@@ -1420,6 +1420,25 @@ MooEditable.Actions = {
 		states: {
 			tags: ['u'],
 			css: {'text-decoration': 'underline'}
+		},
+		events: {
+			beforeToggleView: function(){
+				if(Browser.firefox || Browser.ie){
+					var value = this.textarea.get('value');
+					var newValue = value.replace(/<span style="text-decoration: underline;"([^>]*)>/gi, '<u$1>').replace(/<\/span>/gi, '</u>');
+					if (value != newValue) this.textarea.set('value', newValue);
+				}
+			},
+			attach: function(){
+				if(Browser.firefox || Browser.ie){
+					var value = this.textarea.get('value');
+					var newValue = value.replace(/<span style="text-decoration: underline;"([^>]*)>/gi, '<u$1>').replace(/<\/span>/gi, '</u>');
+					if (value != newValue){
+						this.textarea.set('value', newValue);
+						this.setContent(newValue);
+					}
+				}
+			}
 		}
 	},
 	


### PR DESCRIPTION
For Firefox and IE after serializing generated HTML to storage and dumping data back for edition. Process of underlining back items does not work. Reason is that MooEditable cannot work with span elements that are generated after cleanup function. This fixes the issue.
