### PR TITLE
Added a resize element

### DIFF
--- a/Assets/MooEditable/MooEditable.css
+++ b/Assets/MooEditable/MooEditable.css
@@ -179,3 +179,9 @@
 .mooeditable-ui-button-overlay .overlay-content{
 	padding: 10px;
 }
+
+.mooeditable-resizer {
+	height: 8px;
+	background-color: #eee;
+	border-top: 1px solid #ddd;
+}

--- a/Source/MooEditable/MooEditable.js
+++ b/Source/MooEditable/MooEditable.js
@@ -132,7 +132,10 @@ this.MooEditable = new Class({
 				height: dimensions.y
 			}
 		});
-		
+
+		// Build resizer
+		this.resizer = new Element('div.mooeditable-resizer')
+
 		this.toolbar = new MooEditable.UI.Toolbar({
 			onItemAction: function(){
 				var args = Array.from(arguments);
@@ -176,7 +179,8 @@ this.MooEditable = new Class({
 		this.textarea.setStyle('display', 'none');
 		
 		this.iframe.setStyle('display', '').inject(this.textarea, 'before');
-		
+		this.resizer.inject(this.textarea, 'after');
+
 		Object.each(this.dialogs, function(action, name){
 			Object.each(action, function(dialog){
 				document.id(dialog).inject(self.iframe, 'before');
@@ -1580,5 +1584,52 @@ Element.implement({
 	}
 
 });
+
+var resizingTarget = null
+	, resizingTargetH = null
+	, resizingStartY = null
+
+function resizerOnMouseMove(ev) {
+
+	resizingTarget.setStyle('height', Math.max(resizingTargetH + ev.client.y - resizingStartY, 100))
+}
+
+function resizerDone(ev) {
+
+	window.removeEvent('mousemove', resizerOnMouseMove)
+	window.removeEvent('mouseup', resizerDone)
+
+	if (resizingTarget.tagName == 'IFRAME')
+	{
+		resizingTarget.setStyle('visibility', '')
+	}
+
+	resizingTarget = null
+}
+
+window.addEvent('mousedown:relay(.mooeditable-resizer)', function(ev, el) {
+
+	ev.preventDefault()
+
+	resizingTarget = el.getPrevious()
+
+	if (resizingTarget.getStyle('display') == 'none')
+	{
+		resizingTarget = resizingTarget.getPrevious()
+	}
+
+	resizingTargetH = resizingTarget.getSize().y
+	resizingStartY = ev.client.y
+
+	if (resizingTarget.tagName == 'IFRAME')
+	{
+		resizingTarget.setStyle('visibility', 'hidden')
+	}
+
+	window.addEvents({
+		mousemove: resizerOnMouseMove,
+		mouseup: resizerDone
+	})
+})
 
 })();


### PR DESCRIPTION
Hello,

I added a resize element that works with both the `iframe` and the `textarea` elements.

Currently the `iframe` is hidden when the resizing starts otherwise if the pointer goes over the `iframe` the events are no longer fired and the `mouseup` might be missed.
