### PR TITLE
Quick fix to make sure the render event fires on initialization

### DIFF
--- a/Source/MooEditable/MooEditable.js
+++ b/Source/MooEditable/MooEditable.js
@@ -152,10 +152,11 @@ this.MooEditable = new Class({
 		// Update & cleanup content before submit
 		if (this.options.handleSubmit){
 			this.form = this.textarea.getParent('form');
-			if (!this.form) return;
-			this.form.addEvent('submit', function(){
-				if (self.mode == 'iframe') self.saveContent();
-			});
+			if (this.form) {
+				this.form.addEvent('submit', function(){
+					if (self.mode == 'iframe') self.saveContent();
+				});
+			}
 		}
 		
 		this.fireEvent('render', this);


### PR DESCRIPTION
Hey cheeaun, I was trying to get your render event to fire and found a return statement within a conditional.  I'm assuming the render event isn't meant to be tied to whether or not the editor element lives in a parent form.

Great project by the way, I'm having a blast playing with this code!
